### PR TITLE
update .cdsapirc to use new CDS API url

### DIFF
--- a/2_CDS_Access.ipynb
+++ b/2_CDS_Access.ipynb
@@ -11,9 +11,9 @@
     "\n",
     "<br>\n",
     "<div class=\"alert alert-warning\">\n",
-    "<font face=\"Calibri\" size=\"5\"><b><font color='rgba(200,0,0,0.2)'> <u>The Climate Data Store has migrated to a new website, CDS-Beta</u></font></b></font>\n",
+    "<font face=\"Calibri\" size=\"5\"><b><font color='rgba(200,0,0,0.2)'> <u>The Climate Data Store has migrated to a new website</u></font></b></font>\n",
     "\n",
-    "<font face=\"Calibri\" size=\"3\">The old Climate Data Store (CDS) will no longer be available after September 26, 2024. If you have not yet done so, please follow the instructions below. You will need to create a European Centre for Medium-Range Weather Forecasts (ECMWF) account, accept the terms of use for ERA5 data, and run this notebook to update your `.cdsapirc` file.\n",
+    "<font face=\"Calibri\" size=\"3\">The old Climate Data Store API will no longer be available after September 26, 2024. If you have not yet done so, please follow the instructions below. You will need to create a European Centre for Medium-Range Weather Forecasts (ECMWF) account, accept the terms of use for ERA5 data, and run this notebook to update your `.cdsapirc` file.\n",
     "</font>\n",
     "</div>\n",
     "\n",
@@ -23,7 +23,7 @@
     "- If don't yet have an ECMWF Personal Access Token:\n",
     "    - Proceed to [ECMWF](https://www.ecmwf.int/) and create an account\n",
     "    - Authorize your account by clicking the link in the validation email\n",
-    "    - Proceed to [CDS-Beta](cds-beta.climate.copernicus.eu)\n",
+    "    - Proceed to [CDS](cds.climate.copernicus.eu)\n",
     "    - Click the \"Datasets\" tab\n",
     "    - Search for \"ERA5\"\n",
     "    - Select any of ERA5 datasets that appear\n",
@@ -35,7 +35,7 @@
     "    - Use vim or another text editor to open the `~/.cdsapirc` config file\n",
     "        - Add the CDS url to the first line of the config and your CDS `UID` and CDS`API Key` to the 2nd line of the config\n",
     "            - This should be formatted like:\n",
-    "                - url: https://cds-beta.climate.copernicus.eu/api\n",
+    "                - url: https://cds.climate.copernicus.eu/api\n",
     "                - key: your_personal_access_token\n",
     "        - Save the config and exit the text editor\n",
     "\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31d55fb7-0db7-4a61-a3c4-285a56f321ee",
+   "id": "8213791e-9e33-4306-92c1-81278784c478",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,17 +106,19 @@
     "try:\n",
     "    with open(pyaps_cfg, 'r') as f:\n",
     "        lines = f.readlines()\n",
-    "        if lines and 'cds-beta' in lines[0]:\n",
+    "        if len(lines) > 1 and ('beta' not in lines[0] and 'v2' not in lines[0]):\n",
     "            print(\"Found ECMWF credentials in ~/.cdsapirc\")\n",
     "            print(\"Would you like to update them?\")\n",
     "            update_cds_cfg = osl.select_parameter([\"Do not update my ECMWF personal access token\", \n",
     "                                                    \"Update my ECMWF personal access token\"])\n",
-    "            display(update_cds_cfg)  \n",
-    "        elif lines and 'cds' in lines[0] and 'beta' not in lines[0]:\n",
-    "            print(\"Your ~/.cdsapirc contains credentials for the deprecated CDS website.\")\n",
+    "            display(update_cds_cfg)\n",
+    "        elif len(lines) > 1 and ('beta' in lines[0] or 'v2' in lines[0]):\n",
+    "            print(\"Your ~/.cdsapirc contains credentials for the deprecated CDS or CDS-Beta API.\")\n",
     "            print(\"Run the following code cell to update them.\")\n",
     "            update_cds_cfg = None\n",
     "        else:\n",
+    "            print(\"~/.cdsapirc empty or not found.\")\n",
+    "            print(\"Run the following code cell to create or update one.\")\n",
     "            update_cds_cfg = None\n",
     "except FileNotFoundError:\n",
     "    update_cds_cfg = None"
@@ -142,17 +144,18 @@
     "    with open(pyaps_cfg, 'w') as f:\n",
     "            pac = getpass(\"Enter your ECMWF Personal Access Token\")\n",
     "            lines = ['', '']\n",
-    "            lines[0] = f\"url: https://cds-beta.climate.copernicus.eu/api\\n\"\n",
+    "            lines[0] = f\"url: https://cds.climate.copernicus.eu/api\\n\"\n",
     "            lines[1] = f\"key: {pac}\\n\"\n",
     "            f.seek(0)\n",
     "            f.writelines(lines)\n",
-    "            f.truncate()"
+    "            f.truncate()\n",
+    "print(\"Your ~/.cdsapirc file has been created or updated\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0847d6d3-f28d-440b-b829-628ac0639ca8",
+   "id": "f3414de4-561c-4e07-9490-681fc2223fcd",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -174,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Resolves #23  

`https://cds-beta.climate.copernicus.eu/api` is deprecated. Use `https://cds.climate.copernicus.eu/api`