### PR TITLE
swap mintpy post version for pip install from commit in locked env yaml

### DIFF
--- a/environment_locked.yaml
+++ b/environment_locked.yaml
@@ -364,4 +364,4 @@ dependencies:
       - webencodings==0.5.1
       - websocket-client==1.8.0
       - widgetsnbextension==4.0.10
-      - git+https://github.com/insarlab/MintPy.git@4bbca8c # Install from commit until
+      - git+https://github.com/insarlab/MintPy.git@4bbca8c # Install from commit until release > 1.6.1

--- a/environment_locked.yaml
+++ b/environment_locked.yaml
@@ -327,7 +327,6 @@ dependencies:
       - markdown-it-py==3.0.0
       - matplotlib==3.8.4
       - mdurl==0.1.2
-      - mintpy==1.6.1.post26
       - mistune==3.1.3
       - nbclient==0.10.2
       - nbconvert==7.16.6
@@ -365,3 +364,4 @@ dependencies:
       - webencodings==0.5.1
       - websocket-client==1.8.0
       - widgetsnbextension==4.0.10
+      - git+https://github.com/insarlab/MintPy.git@4bbca8c # Install from commit until


### PR DESCRIPTION
Exporting an env with a dependency installed with pip from a commit will output an uninstallable post version.

This happened in the last PR with MintPY. Fixing this by swapping the post version conda dependency for a pip install from a commit in the exported locked environment yaml.