### PR TITLE
GNSS updates

### DIFF
--- a/Error_Analysis.ipynb
+++ b/Error_Analysis.ipynb
@@ -226,7 +226,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "899fce78-1fae-4676-9233-f5c9aff8c26a",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Download DataHolding.txt and write to GPS_stations.csv\n",
@@ -333,15 +335,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gps_enu2los_path = mint_path / 'gps_enu2los.csv'\n",
+    "gps_enu2los_path = mint_path / 'gnss_enu2los_UNR.csv'\n",
     "vel_path = mint_path / 'velocity.h5'\n",
     "msk_path = mint_path / 'maskTempCoh.h5'\n",
     "with osl.work_dir(plot_path):\n",
-    "    pp.plot_insar_vs_gps_scatter(\n",
-    "        vel_path,\n",
-    "        ref_gps_site=gps_station.value,\n",
-    "        csv_file=gps_enu2los_path,\n",
-    "        msk_file=msk_path,\n",
+    "    pp.plot_insar_vs_gnss_scatter(\n",
+    "        str(vel_path),\n",
+    "        ref_gnss_site=gps_station.value,\n",
+    "        csv_file=str(gps_enu2los_path),\n",
+    "        msk_file=str(msk_path),\n",
     "        # vlim=[-2.5, 2], # option to prune sites that fall outside of a value range (cm)\n",
     "    )"
    ]
@@ -349,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "784dbda3-c9c6-48fe-b22a-973261973047",
+   "id": "62083de6-e8e9-4bfc-8696-f2dfdabafd69",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -371,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,6 +15,7 @@ dependencies:
   - h5py
   - hyp3_sdk
   - ipyfilechooser
+  - libgdal-hdf5
   - numpy
   - pandas
   - pip

--- a/environment_locked.yaml
+++ b/environment_locked.yaml
@@ -5,23 +5,23 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - affine=2.4.0=pyhd8ed1ab_1
-  - asf_search=8.1.2=pyhd8ed1ab_0
-  - asf_search-base=8.1.2=pyhd8ed1ab_0
+  - asf_search=8.1.4=pyhd8ed1ab_0
+  - asf_search-base=8.1.4=pyhd8ed1ab_0
   - asttokens=3.0.0=pyhd8ed1ab_1
   - attrs=25.3.0=pyh71513ae_0
-  - aws-c-auth=0.9.0=h094d708_2
-  - aws-c-cal=0.8.9=hada3f3f_0
+  - aws-c-auth=0.9.0=hf4d4f31_5
+  - aws-c-cal=0.9.0=hada3f3f_0
   - aws-c-common=0.12.2=hb9d3cd8_0
   - aws-c-compression=0.3.1=hc2d532b_4
-  - aws-c-event-stream=0.5.4=h8170a11_5
-  - aws-c-http=0.9.5=hca9d837_2
-  - aws-c-io=0.18.0=h7b13e6b_1
-  - aws-c-mqtt=0.12.3=h773eac8_2
-  - aws-c-s3=0.7.15=h46af1f8_1
+  - aws-c-event-stream=0.5.4=h9312af0_8
+  - aws-c-http=0.10.0=hc373b34_1
+  - aws-c-io=0.19.0=h756d8c7_1
+  - aws-c-mqtt=0.13.0=h2d6f568_1
+  - aws-c-s3=0.7.16=h3b40de3_2
   - aws-c-sdkutils=0.2.3=hc2d532b_4
-  - aws-checksums=0.2.5=hc2d532b_1
-  - aws-crt-cpp=0.32.4=h7d42c6f_0
-  - aws-sdk-cpp=1.11.510=h5b777a2_5
+  - aws-checksums=0.2.7=hc2d532b_0
+  - aws-crt-cpp=0.32.5=he984417_0
+  - aws-sdk-cpp=1.11.510=h7cc6b5f_7
   - azure-core-cpp=1.14.0=h5cfcd09_0
   - azure-identity-cpp=1.10.0=h113e628_0
   - azure-storage-blobs-cpp=12.13.0=h3cf044e_1
@@ -29,22 +29,22 @@ dependencies:
   - azure-storage-files-datalake-cpp=12.12.0=ha633028_1
   - blosc=1.21.6=he440d0b_1
   - bokeh=3.7.2=pyhd8ed1ab_1
-  - boto3=1.38.0=pyhd8ed1ab_0
-  - botocore=1.38.0=pyge310_1234567_0
+  - boto3=1.38.10=pyhd8ed1ab_0
+  - botocore=1.38.10=pyge310_1234567_0
   - branca=0.8.1=pyhd8ed1ab_0
   - brotli=1.1.0=hb9d3cd8_2
   - brotli-bin=1.1.0=hb9d3cd8_2
   - brotli-python=1.1.0=py311hfdbb021_2
   - bzip2=1.0.8=h4bc722e_7
   - c-ares=1.34.5=hb9d3cd8_0
-  - ca-certificates=2025.1.31=hbd8a1cb_1
+  - ca-certificates=2025.4.26=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - cartopy=0.24.0=py311h7db5c69_0
   - cdsapi=0.7.5=pyhd8ed1ab_1
-  - certifi=2025.1.31=pyhd8ed1ab_0
+  - certifi=2025.4.26=pyhd8ed1ab_0
   - cffi=1.17.1=py311hf29c0ef_0
-  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - charset-normalizer=3.4.2=pyhd8ed1ab_0
   - ciso8601=2.3.2=py311h9ecbd09_0
   - click=8.1.8=pyh707e725_0
   - click-plugins=1.1.1=pyhd8ed1ab_1
@@ -56,22 +56,22 @@ dependencies:
   - contourpy=1.3.2=py311hd18a35c_0
   - cycler=0.12.1=pyhd8ed1ab_1
   - cytoolz=1.0.1=py311h9ecbd09_0
-  - dask=2025.4.0=pyhd8ed1ab_0
-  - dask-core=2025.4.0=pyhd8ed1ab_0
+  - dask=2025.4.1=pyhd8ed1ab_0
+  - dask-core=2025.4.1=pyhd8ed1ab_0
   - datapi=0.4.0=pyhd8ed1ab_0
   - dateparser=1.2.1=pyhd8ed1ab_0
   - decorator=5.2.1=pyhd8ed1ab_0
-  - distributed=2025.4.0=pyhd8ed1ab_0
-  - eccodes=2.41.0=h8bb6dbc_0
+  - distributed=2025.4.1=pyhd8ed1ab_0
+  - eccodes=2.41.0=h5f92351_1
   - exceptiongroup=1.2.2=pyhd8ed1ab_1
-  - executing=2.1.0=pyhd8ed1ab_1
+  - executing=2.2.0=pyhd8ed1ab_0
   - folium=0.19.5=pyhd8ed1ab_0
   - fonttools=4.57.0=py311h2dc5d0c_0
   - freeglut=3.2.2=ha6d2627_3
   - freetype=2.13.3=ha770c72_1
   - freexl=2.0.0=h9dce30a_2
   - fsspec=2025.3.2=pyhd8ed1ab_0
-  - gdal=3.10.3=py311hef8459e_3
+  - gdal=3.10.3=py311hef8459e_6
   - geographiclib=2.0=pyhd8ed1ab_1
   - geopandas=1.0.1=pyhd8ed1ab_3
   - geopandas-base=1.0.1=pyha770c72_3
@@ -82,9 +82,9 @@ dependencies:
   - giflib=5.2.2=hd590300_0
   - glog=0.7.1=hbabe93e_0
   - h2=4.2.0=pyhd8ed1ab_0
-  - h5py=3.13.0=nompi_py311hb639ac4_100
+  - h5py=3.13.0=nompi_py311h38436b4_101
   - hdf4=4.2.15=h2a13503_7
-  - hdf5=1.14.3=nompi_h2d575fe_109
+  - hdf5=1.14.6=nompi_h2d575fe_101
   - hpack=4.1.0=pyhd8ed1ab_0
   - hyp3_sdk=7.3.0=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
@@ -98,7 +98,7 @@ dependencies:
   - jedi=0.19.2=pyhd8ed1ab_1
   - jinja2=3.1.6=pyhd8ed1ab_0
   - jmespath=1.0.1=pyhd8ed1ab_1
-  - joblib=1.4.2=pyhd8ed1ab_1
+  - joblib=1.5.0=pyhd8ed1ab_0
   - json-c=0.18=h6688a6e_0
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.7=py311hd18a35c_0
@@ -109,10 +109,10 @@ dependencies:
   - libabseil=20250127.1=cxx17_hbbce691_0
   - libaec=1.1.3=h59595ed_0
   - libarchive=3.7.7=h75ea233_4
-  - libarrow=19.0.1=h27f8bab_8_cpu
-  - libarrow-acero=19.0.1=hcb10f89_8_cpu
-  - libarrow-dataset=19.0.1=hcb10f89_8_cpu
-  - libarrow-substrait=19.0.1=h1bed206_8_cpu
+  - libarrow=20.0.0=hebdba27_2_cpu
+  - libarrow-acero=20.0.0=hcb10f89_2_cpu
+  - libarrow-dataset=20.0.0=hcb10f89_2_cpu
+  - libarrow-substrait=20.0.0=h1bed206_2_cpu
   - libblas=3.9.0=31_h59b9bed_openblas
   - libbrotlicommon=1.1.0=hb9d3cd8_2
   - libbrotlidec=1.1.0=hb9d3cd8_2
@@ -130,16 +130,17 @@ dependencies:
   - libffi=3.4.6=h2dba641_1
   - libfreetype=2.13.3=ha770c72_1
   - libfreetype6=2.13.3=h48d6fc4_1
-  - libgcc=14.2.0=h767d61c_2
-  - libgcc-ng=14.2.0=h69a702a_2
-  - libgdal-core=3.10.3=hab2de9c_3
-  - libgfortran=14.2.0=h69a702a_2
-  - libgfortran5=14.2.0=hf1ad2bd_2
+  - libgcc=15.1.0=h767d61c_2
+  - libgcc-ng=15.1.0=h69a702a_2
+  - libgdal-core=3.10.3=hc58de80_6
+  - libgdal-hdf5=3.10.3=heb3e146_6
+  - libgfortran=15.1.0=h69a702a_2
+  - libgfortran5=15.1.0=hcea5267_2
   - libgl=1.7.0=ha4b6fd6_2
   - libglu=9.0.3=h03adeef_0
   - libglvnd=1.7.0=ha4b6fd6_2
   - libglx=1.7.0=ha4b6fd6_2
-  - libgomp=14.2.0=h767d61c_2
+  - libgomp=15.1.0=h767d61c_2
   - libgoogle-cloud=2.36.0=hc4361e1_1
   - libgoogle-cloud-storage=2.36.0=h0121fbd_1
   - libgrpc=1.71.0=h8e591d7_1
@@ -147,24 +148,24 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - libkml=1.3.0=hf539b9f_1021
   - liblapack=3.9.0=31_h7ac8fdf_openblas
-  - liblzma=5.8.1=hb9d3cd8_0
-  - libnetcdf=4.9.2=nompi_h00e09a9_116
+  - liblzma=5.8.1=hb9d3cd8_1
+  - libnetcdf=4.9.2=nompi_h0134ee8_117
   - libnghttp2=1.64.0=h161d5f1_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.29=pthreads_h94d23a6_0
   - libopentelemetry-cpp=1.20.0=hd1b1c89_0
   - libopentelemetry-cpp-headers=1.20.0=ha770c72_0
-  - libparquet=19.0.1=h081d1f1_8_cpu
+  - libparquet=20.0.0=h081d1f1_2_cpu
   - libpciaccess=0.18=hd590300_0
   - libpng=1.6.47=h943b412_0
   - libprotobuf=5.29.3=h501fc15_1
   - libre2-11=2024.07.02=hba17884_3
   - librttopo=1.1.0=hd718a1a_18
   - libspatialite=5.1.0=he17ca71_14
-  - libsqlite=3.49.1=hee588c1_2
-  - libssh2=1.11.1=hf672d98_0
-  - libstdcxx=14.2.0=h8f9b012_2
-  - libstdcxx-ng=14.2.0=h4852527_2
+  - libsqlite=3.49.2=hee588c1_0
+  - libssh2=1.11.1=hcf80075_0
+  - libstdcxx=15.1.0=h8f9b012_2
+  - libstdcxx-ng=15.1.0=h4852527_2
   - libthrift=0.21.0=h0e7cc3e_0
   - libtiff=4.7.0=hd9ff511_4
   - libutf8proc=2.10.0=h4c51ac1_0
@@ -172,38 +173,38 @@ dependencies:
   - libwebp-base=1.5.0=h851e524_0
   - libxcb=1.17.0=h8a09558_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.7=h4bc477f_1
+  - libxml2=2.13.8=h4bc477f_0
   - libzip=1.11.2=h6991a6a_0
   - libzlib=1.3.1=hb9d3cd8_2
   - locket=1.0.0=pyhd8ed1ab_0
-  - lz4=4.3.3=py311h8c6ae76_2
+  - lz4=4.4.4=py311h8c6ae76_0
   - lz4-c=1.10.0=h5888daf_1
   - lzo=2.10=hd590300_1001
   - mapclassify=2.8.1=pyhd8ed1ab_1
   - markupsafe=3.0.2=py311h2dc5d0c_1
   - matplotlib-inline=0.1.7=pyhd8ed1ab_1
   - mercantile=1.2.1=pyhd8ed1ab_1
-  - minizip=4.0.9=h05a5f5f_0
+  - minizip=4.0.10=h05a5f5f_0
   - msgpack-python=1.1.0=py311hd18a35c_0
   - multiurl=0.3.5=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
-  - narwhals=1.36.0=pyh29332c3_0
+  - narwhals=1.38.0=pyhe01879c_0
   - ncurses=6.5=h2d0b736_3
   - networkx=3.4.2=pyh267e887_2
   - nlohmann_json=3.12.0=h3f2d84a_0
   - numpy=2.2.5=py311h5d046bc_0
   - openjpeg=2.5.3=h5fbd93e_0
-  - openssl=3.5.0=h7b32b05_0
-  - orc=2.1.1=h17f744e_1
+  - openssl=3.5.0=h7b32b05_1
+  - orc=2.1.2=h17f744e_0
   - packaging=25.0=pyh29332c3_1
   - pandas=2.2.3=py311h7db5c69_3
   - parso=0.8.4=pyhd8ed1ab_1
   - partd=1.4.2=pyhd8ed1ab_0
-  - pcre2=10.44=hba22ea6_2
+  - pcre2=10.45=hc749103_0
   - pexpect=4.9.0=pyhd8ed1ab_1
   - pickleshare=0.7.5=pyhd8ed1ab_1004
-  - pillow=11.1.0=py311h1322bbf_0
-  - pip=25.0.1=pyh8b19718_0
+  - pillow=11.2.1=py311h1322bbf_0
+  - pip=25.1.1=pyh8b19718_0
   - proj=9.6.0=h0054346_1
   - prometheus-cpp=1.3.0=ha5d0236_0
   - prompt-toolkit=3.0.51=pyha770c72_0
@@ -211,8 +212,8 @@ dependencies:
   - pthread-stubs=0.4=hb9d3cd8_1002
   - ptyprocess=0.7.0=pyhd8ed1ab_1
   - pure_eval=0.2.3=pyhd8ed1ab_1
-  - pyarrow=19.0.1=py311h38be061_0
-  - pyarrow-core=19.0.1=py311h4854187_0_cpu
+  - pyarrow=20.0.0=py311h38be061_0
+  - pyarrow-core=20.0.0=py311h4854187_0_cpu
   - pycparser=2.22=pyh29332c3_1
   - pygments=2.19.1=pyhd8ed1ab_0
   - pygrib=2.1.6=py311h8aeb462_1
@@ -235,17 +236,17 @@ dependencies:
   - remotezip=0.12.3=pyhd8ed1ab_1
   - requests=2.32.3=pyhd8ed1ab_1
   - rioxarray=0.19.0=pyhd8ed1ab_0
-  - s2n=1.5.16=hba75a32_1
+  - s2n=1.5.18=h763c568_1
   - s3transfer=0.12.0=pyhd8ed1ab_0
   - scikit-learn=1.6.1=py311h57cc02b_0
   - scipy=1.15.2=py311h8f841c2_0
-  - setuptools=79.0.0=pyhff2d567_0
+  - setuptools=80.1.0=pyhff2d567_0
   - shapely=2.1.0=py311h3dc67b8_0
   - six=1.17.0=pyhd8ed1ab_0
   - snappy=1.2.1=h8bd8927_1
   - snuggs=1.4.7=pyhd8ed1ab_2
   - sortedcontainers=2.4.0=pyhd8ed1ab_1
-  - sqlite=3.49.1=h9eae976_2
+  - sqlite=3.49.2=h9eae976_0
   - stack_data=0.6.3=pyhd8ed1ab_1
   - tblib=3.1.0=pyhd8ed1ab_0
   - tenacity=8.2.2=pyhd8ed1ab_0
@@ -263,7 +264,7 @@ dependencies:
   - urllib3=2.4.0=pyhd8ed1ab_0
   - wcwidth=0.2.13=pyhd8ed1ab_1
   - wheel=0.45.1=pyhd8ed1ab_1
-  - xarray=2025.3.1=pyhd8ed1ab_0
+  - xarray=2025.4.0=pyhd8ed1ab_0
   - xerces-c=3.2.5=h988505b_2
   - xorg-libx11=1.8.12=h4f16b4b_0
   - xorg-libxau=1.0.12=hb9d3cd8_0
@@ -273,12 +274,12 @@ dependencies:
   - xorg-libxfixes=6.0.1=hb9d3cd8_0
   - xorg-libxi=1.8.2=hb9d3cd8_0
   - xorg-libxxf86vm=1.1.6=hb9d3cd8_0
-  - xyzservices=2025.1.0=pyhd8ed1ab_0
+  - xyzservices=2025.4.0=pyhd8ed1ab_0
   - yaml=0.2.5=h7f98852_2
   - zict=3.0.0=pyhd8ed1ab_1
   - zipp=3.21.0=pyhd8ed1ab_1
   - zlib=1.3.1=hb9d3cd8_2
-  - zstandard=0.23.0=py311h9ecbd09_1
+  - zstandard=0.23.0=py311h9ecbd09_2
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
       - anyio==4.9.0
@@ -298,13 +299,13 @@ dependencies:
       - donfig==0.8.1.post1
       - fastjsonschema==2.21.1
       - fqdn==1.5.1
-      - h11==0.14.0
-      - httpcore==1.0.8
+      - h11==0.16.0
+      - httpcore==1.0.9
       - httpx==0.28.1
       - imageio==2.37.0
       - ipykernel==6.29.5
       - ipympl==0.9.2
-      - ipython==8.35.0
+      - ipython==8.36.0
       - ipython-genutils==0.2.0
       - ipywidgets==8.1.2
       - isoduration==20.11.0
@@ -327,6 +328,7 @@ dependencies:
       - markdown-it-py==3.0.0
       - matplotlib==3.8.4
       - mdurl==0.1.2
+      - git+https://github.com/insarlab/MintPy.git@4bbca8c # Install from commit until release > 1.6.1
       - mistune==3.1.3
       - nbclient==0.10.2
       - nbconvert==7.16.6
@@ -334,7 +336,7 @@ dependencies:
       - nest-asyncio==1.6.0
       - notebook==7.1.3
       - notebook-shim==0.2.4
-      - opensarlab-lib==0.0.11
+      - opensarlab-lib==0.0.14
       - overrides==7.7.0
       - pandocfilters==1.5.1
       - platformdirs==4.3.7
@@ -364,4 +366,3 @@ dependencies:
       - webencodings==0.5.1
       - websocket-client==1.8.0
       - widgetsnbextension==4.0.10
-      - git+https://github.com/insarlab/MintPy.git@4bbca8c # Install from commit until release > 1.6.1

--- a/util/gps.py
+++ b/util/gps.py
@@ -119,11 +119,9 @@ def get_gps_stations(mint_path: Union[str, os.PathLike], filename='GPS_stations.
                 if yx_vel not in [0.0, np.nan]:
                     gps_stations.append(row[0].strip())
     
-    # There must be at least 2 GPS stations in your AOI
-    gps = len(gps_stations) > 1
-    if not gps:
+    if len(gps_stations) < 2:
         print("There were fewer than 2 GPS sites found in your AOI")
-        return gps_stations
+        return None
     else:
         return gps_stations
 


### PR DESCRIPTION
- Account for timeseries data in UTM when intersecting GPS locations
- Use updated MintPy gnss functions ("gps" changed to "gnss" in function names, args, and output filenames
- Install libgdal-hdf5