### PR TITLE
install mintpy from insarlab lab main

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -32,5 +32,5 @@ dependencies:
   - ipyleaflet
   - pip:
     - opensarlab_lib 
-    - git+https://github.com/ASFOpenSARlab/MintPy.git@56974a3 # Fork contains dem error bug fix where dem_error.py and plot.py don't handle tuples with 1 element instead of the expected scalar
+    - git+https://github.com/insarlab/MintPy.git@9852991
     - git+https://github.com/insarlab/PyAPS.git@6b01c39 #0.3.6 CDS downloads fail from MintPy, install from source until 0.3.7

--- a/environment_locked.yaml
+++ b/environment_locked.yaml
@@ -1,28 +1,26 @@
 name: opensarlab_mintpy_recipe_book
 channels:
   - conda-forge
-  - nodefaults
 dependencies:
-  - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
+  - _openmp_mutex=4.5=20_gnu
   - affine=2.4.0=pyhd8ed1ab_1
-  - asf_search=11.0.3=pyhd8ed1ab_0
-  - asf_search-base=11.0.3=pyhd8ed1ab_0
+  - asf_search=12.0.3=pyhd8ed1ab_0
+  - asf_search-base=12.0.3=pyhd8ed1ab_0
   - asttokens=3.0.1=pyhd8ed1ab_0
   - attrs=25.4.0=pyhcf101f3_1
-  - aws-c-auth=0.9.3=hef928c7_0
+  - aws-c-auth=0.9.6=hb9c0fe4_1
   - aws-c-cal=0.9.13=h2c9d079_1
   - aws-c-common=0.12.6=hb03c661_0
-  - aws-c-compression=0.3.1=h8b1a151_9
-  - aws-c-event-stream=0.5.7=h28f887f_1
-  - aws-c-http=0.10.7=ha8fc4e3_5
-  - aws-c-io=0.23.3=hdaf4b65_5
-  - aws-c-mqtt=0.13.3=hc63082f_11
-  - aws-c-s3=0.11.3=h06ab39a_1
+  - aws-c-compression=0.3.2=h8b1a151_0
+  - aws-c-event-stream=0.5.9=h841be55_2
+  - aws-c-http=0.10.10=hf621c6d_0
+  - aws-c-io=0.26.1=h3ca20c3_1
+  - aws-c-mqtt=0.14.0=ha25ca29_1
+  - aws-c-s3=0.11.5=h9b5df67_3
   - aws-c-sdkutils=0.2.4=h8b1a151_4
-  - aws-checksums=0.2.7=h8b1a151_5
-  - aws-crt-cpp=0.35.4=h8824e59_0
-  - aws-sdk-cpp=1.11.606=h20b40b1_10
+  - aws-checksums=0.2.10=h8b1a151_0
+  - aws-crt-cpp=0.37.3=hb153662_0
+  - aws-sdk-cpp=1.11.747=h133b1ee_1
   - azure-core-cpp=1.16.2=h206d751_0
   - azure-identity-cpp=1.13.3=hed0cdb0_1
   - azure-storage-blobs-cpp=12.16.0=hdd73cc9_1
@@ -30,21 +28,21 @@ dependencies:
   - azure-storage-files-datalake-cpp=12.14.0=h52c5a47_1
   - backports.zstd=1.3.0=py311h6b1f9c4_0
   - blosc=1.21.6=he440d0b_1
-  - bokeh=3.8.2=pyhd8ed1ab_0
-  - boto3=1.42.44=pyhd8ed1ab_0
-  - botocore=1.42.44=pyhd8ed1ab_0
+  - bokeh=3.9.0=pyhd8ed1ab_0
+  - boto3=1.42.66=pyhd8ed1ab_0
+  - botocore=1.42.66=pyhd8ed1ab_0
   - branca=0.8.2=pyhd8ed1ab_0
   - brotli=1.2.0=hed03a55_1
   - brotli-bin=1.2.0=hb03c661_1
   - brotli-python=1.2.0=py311h66f275b_1
-  - bzip2=1.0.8=hda65f42_8
+  - bzip2=1.0.8=hda65f42_9
   - c-ares=1.34.6=hb03c661_0
-  - ca-certificates=2026.1.4=hbd8a1cb_0
+  - ca-certificates=2026.2.25=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - cartopy=0.25.0=py311hed34c8f_1
-  - certifi=2026.1.4=pyhd8ed1ab_0
-  - charset-normalizer=3.4.4=pyhd8ed1ab_0
+  - certifi=2026.2.25=pyhd8ed1ab_0
+  - charset-normalizer=3.4.5=pyhd8ed1ab_0
   - ciso8601=2.3.3=py311haee01d2_1
   - click=8.3.1=pyh8f84b5b_1
   - click-plugins=1.1.1.2=pyhd8ed1ab_0
@@ -54,23 +52,23 @@ dependencies:
   - contextily=1.7.0=pyhd8ed1ab_0
   - contourpy=1.3.3=py311h724c32c_4
   - cycler=0.12.1=pyhcf101f3_2
-  - cytoolz=1.1.0=py311h49ec1c0_1
-  - dask=2026.1.2=pyhcf101f3_0
+  - cytoolz=1.1.0=py311h49ec1c0_2
+  - dask=2026.1.2=pyhcf101f3_1
   - dask-core=2026.1.2=pyhcf101f3_0
   - dateparser=1.3.0=pyhd8ed1ab_0
   - debugpy=1.8.20=py311hc665b79_0
   - decorator=5.2.1=pyhd8ed1ab_0
-  - distributed=2026.1.2=pyhcf101f3_0
+  - distributed=2026.1.2=pyhcf101f3_1
   - executing=2.2.1=pyhd8ed1ab_0
   - folium=0.20.0=pyhd8ed1ab_0
-  - fonttools=4.61.1=py311h3778330_0
-  - freetype=2.14.1=ha770c72_0
+  - fonttools=4.62.0=py311h3778330_0
+  - freetype=2.14.2=ha770c72_0
   - freexl=2.0.0=h9dce30a_2
   - fsspec=2026.2.0=pyhd8ed1ab_0
-  - gdal=3.12.1=py311h34ccccb_1
+  - gdal=3.12.2=py311hd474574_3
   - geographiclib=2.1=pyhd8ed1ab_0
-  - geopandas=1.1.2=pyhd8ed1ab_0
-  - geopandas-base=1.1.2=pyha770c72_0
+  - geopandas=1.1.3=pyhd8ed1ab_0
+  - geopandas-base=1.1.3=pyha770c72_0
   - geopy=2.4.1=pyhd8ed1ab_2
   - geos=3.14.1=h480dda7_0
   - gflags=2.2.2=h5888daf_1005
@@ -102,67 +100,67 @@ dependencies:
   - jupyter_leaflet=0.20.0=pyhd8ed1ab_0
   - jupyterlab_widgets=3.0.16=pyhcf101f3_1
   - keyutils=1.6.3=hb9d3cd8_0
-  - kiwisolver=1.4.9=py311h724c32c_2
-  - krb5=1.21.3=h659f571_0
+  - kiwisolver=1.5.0=py311h724c32c_0
+  - krb5=1.22.2=ha1258a1_0
   - lcms2=2.18=h0c24ade_0
   - ld_impl_linux-64=2.45.1=default_hbd61a6d_101
-  - lerc=4.0.0=h0aef613_1
-  - libabseil=20250512.1=cxx17_hba17884_0
+  - lerc=4.1.0=hdb68285_0
+  - libabseil=20260107.1=cxx17_h7b12aa8_0
   - libaec=1.1.5=h088129d_0
-  - libarchive=3.8.5=gpl_hc2c16d8_100
-  - libarrow=23.0.0=h40b5c2d_2_cpu
-  - libarrow-acero=23.0.0=h635bf11_2_cpu
-  - libarrow-compute=23.0.0=h8c2c5c3_2_cpu
-  - libarrow-dataset=23.0.0=h635bf11_2_cpu
-  - libarrow-substrait=23.0.0=h3f74fd7_2_cpu
+  - libarchive=3.8.6=gpl_hc2c16d8_100
+  - libarrow=23.0.1=hf605819_4_cpu
+  - libarrow-acero=23.0.1=h635bf11_4_cpu
+  - libarrow-compute=23.0.1=h53684a4_4_cpu
+  - libarrow-dataset=23.0.1=h635bf11_4_cpu
+  - libarrow-substrait=23.0.1=hb4dd7c2_4_cpu
   - libblas=3.11.0=5_h4a7cf45_openblas
   - libbrotlicommon=1.2.0=hb03c661_1
   - libbrotlidec=1.2.0=hb03c661_1
   - libbrotlienc=1.2.0=hb03c661_1
   - libcblas=3.11.0=5_h0358290_openblas
   - libcrc32c=1.1.2=h9c3ff4c_0
-  - libcurl=8.18.0=h4e3cde8_0
+  - libcurl=8.19.0=hcf29cc6_0
   - libdeflate=1.25=h17f619e_0
   - libedit=3.1.20250104=pl5321h7949ede_0
   - libev=4.33=hd590300_2
   - libevent=2.1.12=hf998b51_1
-  - libexpat=2.7.3=hecca717_0
+  - libexpat=2.7.4=hecca717_0
   - libffi=3.5.2=h3435931_0
-  - libfreetype=2.14.1=ha770c72_0
-  - libfreetype6=2.14.1=h73754d4_0
-  - libgcc=15.2.0=he0feb66_17
-  - libgcc-ng=15.2.0=h69a702a_17
-  - libgdal-core=3.12.1=hf05ffb4_1
-  - libgdal-hdf5=3.12.1=h966a9c2_1
-  - libgfortran=15.2.0=h69a702a_17
-  - libgfortran5=15.2.0=h68bc16d_17
-  - libgomp=15.2.0=he0feb66_17
-  - libgoogle-cloud=2.39.0=hdb79228_0
-  - libgoogle-cloud-storage=2.39.0=hdbdcf42_0
-  - libgrpc=1.73.1=h3288cfb_1
+  - libfreetype=2.14.2=ha770c72_0
+  - libfreetype6=2.14.2=h73754d4_0
+  - libgcc=15.2.0=he0feb66_18
+  - libgcc-ng=15.2.0=h69a702a_18
+  - libgdal-core=3.12.2=he63569f_2
+  - libgdal-hdf5=3.12.2=hcaab353_2
+  - libgfortran=15.2.0=h69a702a_18
+  - libgfortran5=15.2.0=h68bc16d_18
+  - libgomp=15.2.0=he0feb66_18
+  - libgoogle-cloud=2.39.0=h9d11ab5_1
+  - libgoogle-cloud-storage=2.39.0=hdbdcf42_1
+  - libgrpc=1.78.0=h1d1128b_1
   - libhwy=1.3.0=h4c17acf_1
   - libiconv=1.18=h3b78370_2
   - libjpeg-turbo=3.1.2=hb03c661_0
-  - libjxl=0.11.1=ha09017c_8
+  - libjxl=0.11.2=ha09017c_0
   - libkml=1.3.0=haa4a5bd_1022
   - liblapack=3.11.0=5_h47877c9_openblas
   - liblzma=5.8.2=hb03c661_0
   - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_4
-  - libopentelemetry-cpp=1.21.0=hb9b0907_1
-  - libopentelemetry-cpp-headers=1.21.0=ha770c72_1
-  - libparquet=23.0.0=h7376487_2_cpu
-  - libpng=1.6.54=h421ea60_0
-  - libprotobuf=6.31.1=h49aed37_4
-  - libre2-11=2025.11.05=h7b12aa8_0
+  - libopentelemetry-cpp=1.21.0=h9692893_2
+  - libopentelemetry-cpp-headers=1.21.0=ha770c72_2
+  - libparquet=23.0.1=h7376487_4_cpu
+  - libpng=1.6.55=h421ea60_0
+  - libprotobuf=6.33.5=h2b00c02_0
+  - libre2-11=2025.11.05=h0dc7533_1
   - librttopo=1.1.0=h46dd2a8_20
-  - libsodium=1.0.20=h4ab18f5_0
+  - libsodium=1.0.21=h280c20c_3
   - libspatialite=5.1.0=gpl_h2abfd87_119
-  - libsqlite=3.51.2=hf4e2dac_0
+  - libsqlite=3.52.0=hf4e2dac_0
   - libssh2=1.11.1=hcf80075_0
-  - libstdcxx=15.2.0=h934c35e_17
-  - libstdcxx-ng=15.2.0=hdf11a46_17
+  - libstdcxx=15.2.0=h934c35e_18
+  - libstdcxx-ng=15.2.0=hdf11a46_18
   - libthrift=0.22.0=h454ac66_1
   - libtiff=4.7.1=h9d88235_1
   - libutf8proc=2.11.3=hfe17d71_0
@@ -170,16 +168,16 @@ dependencies:
   - libwebp-base=1.6.0=hd42ef1d_0
   - libxcb=1.17.0=h8a09558_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.15.1=he237659_1
-  - libxml2-16=2.15.1=hca6bf5a_1
-  - libxml2-devel=2.15.1=he237659_1
+  - libxml2=2.15.2=he237659_0
+  - libxml2-16=2.15.2=hca6bf5a_0
+  - libxml2-devel=2.15.2=he237659_0
   - libzlib=1.3.1=hb9d3cd8_2
   - locket=1.0.0=pyhd8ed1ab_0
   - lz4=4.4.5=py311h1c460e0_1
   - lz4-c=1.10.0=h5888daf_1
   - lzo=2.10=h280c20c_1002
   - mapclassify=2.10.0=pyhd8ed1ab_1
-  - markupsafe=3.0.3=py311h3778330_0
+  - markupsafe=3.0.3=py311h3778330_1
   - matplotlib-base=3.10.8=py311h0f3be63_0
   - matplotlib-inline=0.2.1=pyhd8ed1ab_0
   - mercantile=1.2.1=pyhd8ed1ab_1
@@ -187,7 +185,7 @@ dependencies:
   - msgpack-python=1.1.2=py311hdf67eae_1
   - munkres=1.1.4=pyhd8ed1ab_1
   - muparser=2.3.5=h5888daf_0
-  - narwhals=2.16.0=pyhcf101f3_0
+  - narwhals=2.18.0=pyhcf101f3_0
   - ncurses=6.5=h2d0b736_3
   - nest-asyncio=1.6.0=pyhd8ed1ab_1
   - networkx=3.6.1=pyhcf101f3_0
@@ -195,56 +193,56 @@ dependencies:
   - numpy=2.4.2=py311h2e04523_1
   - openjpeg=2.5.4=h55fea9a_0
   - openssl=3.6.1=h35e630c_1
-  - orc=2.2.2=h19cb568_0
+  - orc=2.3.0=h21090e2_0
   - packaging=26.0=pyhcf101f3_0
-  - pandas=3.0.0=py311h8032f78_0
-  - parso=0.8.5=pyhcf101f3_0
+  - pandas=3.0.1=py311h8032f78_0
+  - parso=0.8.6=pyhcf101f3_0
   - partd=1.4.2=pyhd8ed1ab_0
   - pcre2=10.47=haa7fec5_0
   - pexpect=4.9.0=pyhd8ed1ab_1
-  - pillow=12.1.0=py311hf88fc01_0
+  - pillow=12.1.1=py311hf88fc01_0
   - pip=26.0.1=pyh8b19718_0
-  - platformdirs=4.5.1=pyhcf101f3_0
-  - proj=9.7.1=he0df7b0_2
+  - platformdirs=4.9.4=pyhcf101f3_0
+  - proj=9.7.1=he0df7b0_3
   - prometheus-cpp=1.3.0=ha5d0236_0
   - prompt-toolkit=3.0.52=pyha770c72_0
   - psutil=7.2.2=py311haee01d2_0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - ptyprocess=0.7.0=pyhd8ed1ab_1
   - pure_eval=0.2.3=pyhd8ed1ab_1
-  - pyarrow=23.0.0=py311h38be061_0
-  - pyarrow-core=23.0.0=py311h342b5a4_0_cpu
+  - pyarrow=23.0.1=py311h38be061_0
+  - pyarrow-core=23.0.1=py311h66caee6_0_cpu
   - pygments=2.19.2=pyhd8ed1ab_0
   - pyogrio=0.12.1=py311h422ce6a_0
   - pyparsing=3.3.2=pyhcf101f3_0
-  - pyproj=3.7.2=py311h4e6619b_2
+  - pyproj=3.7.2=py311h400b93a_3
   - pyshp=3.0.3=pyhd8ed1ab_0
   - pysocks=1.7.1=pyha55dd90_7
-  - python=3.11.14=hd63d673_3_cpython
+  - python=3.11.15=hd63d673_0_cpython
   - python-dateutil=2.9.0.post0=pyhe01879c_2
   - python_abi=3.11=8_cp311
   - pytz=2025.2=pyhd8ed1ab_0
   - pyyaml=6.0.3=py311h3778330_1
-  - pyzmq=27.1.0=py311h2315fbb_0
+  - pyzmq=27.1.0=py311h57d2397_2
   - qhull=2020.2=h434a139_5
   - rasterio=1.4.4=py311hf34719e_2
-  - re2=2025.11.05=h5301d42_0
+  - re2=2025.11.05=h5301d42_1
   - readline=8.3=h853b02a_0
-  - regex=2026.1.15=py311h49ec1c0_0
+  - regex=2026.2.28=py311h49ec1c0_0
   - remotezip=0.12.3=pyhd8ed1ab_1
   - requests=2.32.5=pyhcf101f3_1
   - rioxarray=0.19.0=pyhd8ed1ab_0
-  - s2n=1.6.2=he8a4886_1
+  - s2n=1.7.0=ha63dd3a_1
   - s3transfer=0.16.0=pyhd8ed1ab_0
   - scikit-learn=1.8.0=np2py311ha15b03d_1
-  - scipy=1.17.0=py311hbe70eeb_1
-  - setuptools=81.0.0=pyh332efcf_0
+  - scipy=1.17.1=py311hbe70eeb_0
+  - setuptools=82.0.1=pyh332efcf_0
   - shapely=2.1.2=py311h8a92878_2
   - six=1.17.0=pyhe01879c_1
   - snappy=1.2.2=h03e3b7b_1
   - snuggs=1.4.7=pyhd8ed1ab_2
   - sortedcontainers=2.4.0=pyhd8ed1ab_1
-  - sqlite=3.51.2=h04a0ce9_0
+  - sqlite=3.52.0=h04a0ce9_0
   - stack_data=0.6.3=pyhd8ed1ab_1
   - tblib=3.2.2=pyhcf101f3_0
   - tenacity=8.2.2=pyhd8ed1ab_0
@@ -258,49 +256,58 @@ dependencies:
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025c=hc9c84f9_1
   - tzlocal=5.3.1=pyh8f84b5b_0
-  - unicodedata2=17.0.0=py311h49ec1c0_1
+  - unicodedata2=17.0.1=py311h49ec1c0_0
   - uriparser=0.9.8=hac33072_0
   - urllib3=2.6.3=pyhd8ed1ab_0
-  - wcwidth=0.5.3=pyhd8ed1ab_0
+  - wcwidth=0.6.0=pyhd8ed1ab_0
   - wheel=0.46.3=pyhd8ed1ab_0
   - widgetsnbextension=4.0.15=pyhd8ed1ab_0
-  - xarray=2026.1.0=pyhcf101f3_0
+  - xarray=2026.2.0=pyhcf101f3_0
   - xerces-c=3.3.0=hd9031aa_1
   - xorg-libxau=1.0.12=hb03c661_1
   - xorg-libxdmcp=1.1.5=hb03c661_1
   - xyzservices=2025.11.0=pyhd8ed1ab_0
   - yaml=0.2.5=h280c20c_3
-  - zeromq=4.3.5=h387f397_9
+  - zeromq=4.3.5=h41580af_10
   - zict=3.0.0=pyhd8ed1ab_1
   - zipp=3.23.0=pyhcf101f3_1
   - zlib=1.3.1=hb9d3cd8_2
   - zlib-ng=2.3.3=hceb46e0_1
   - zstd=1.5.7=hb78ec9c_6
   - pip:
-    - ImageIO==2.37.2
+    - ImageIO==2.37.3
+    - SecretStorage==3.3.3
     - argcomplete==3.6.3
+    - backports.tarfile==1.2.0
     - cdsapi==0.7.7
     - configobj==5.0.9
-    - cvxopt==1.3.2
+    - cvxopt==1.3.3
     - dask-jobqueue==0.9.0
+    - docutils==0.21.2
     - donfig==0.8.1.post1
     - ecmwf-datastores-client==0.4.2
-    - lazy_loader==0.4
+    - id==1.5.0
+    - jaraco.context==6.0.1
+    - keyring==25.6.0
+    - lazy-loader==0.5
     - lxml==6.0.2
     - markdown-it-py==4.0.0
     - mdurl==0.1.2
+    - git+https://github.com/insarlab/MintPy.git@9852991
     - multiurl==0.3.7
     - nbgitpuller==1.2.2
     - opensarlab_lib==0.0.14
+    - git+https://github.com/insarlab/PyAPS.git@6b01c39
     - pygrib==2.1.8
     - pykdtree==1.4.3
     - pykml==0.2.0
     - pyresample==1.35.0
     - pysolid==0.3.4
-    - rich==14.3.2
+    - readme_renderer==44.0
+    - requests-toolbelt==1.0.0
+    - rich==14.3.3
     - scikit-image==0.26.0
-    - tifffile==2026.1.28
+    - tifffile==2026.3.3
+    - twine==6.1.0
     - utm==0.8.1
-    - git+https://github.com/ASFOpenSARlab/MintPy.git@56974a3 # Fork contains dem error bug fix where dem_error.py and plot.py don't handle tuples with 1 element instead of the expected scalar
-    - git+https://github.com/insarlab/PyAPS.git@6b01c39 #0.3.6 CDS downloads fail from MintPy, install from source until 0.3.7
 


### PR DESCRIPTION
- Commit-based pip installations of MintPy in environment.yamls were broken after rebasing ASFOpenSARlab's MintPy fork to upstream main. Upstream main now has the fix from ASFOpenSARlab's fork merged, so yamls have been updated to install from insarlab/MintPy instead of the fork. 