### PR TITLE
Output_GeoTiff.ipynb fixes

### DIFF
--- a/Output_GeoTiff.ipynb
+++ b/Output_GeoTiff.ipynb
@@ -126,6 +126,7 @@
     "geotiff_path = mint_path/'GeoTiffs'\n",
     "ts_demErr_path = list(mint_path.glob('timeseries*_demErr.h5'))[0]\n",
     "disp_path = geotiff_path / 'displacement_maps'\n",
+    "disp_path.mkdir(parents=True, exist_ok=True)\n",
     "unwrapped_path = disp_path / 'unwrapped'\n",
     "wrapped_path = disp_path / 'wrapped'"
    ]
@@ -443,25 +444,32 @@
    "source": [
     "<hr>\n",
     "\n",
-    "## 8. Save the Velocity GeoTiff"
+    "## 8. Save the Velocity and VelocityERA5 GeoTiffs\n",
+    "\n",
+    "- velocity.h5: The estimated ground deformation velocity. \n",
+    "- velocityERA5.h5: The estimated velocity contribution from the ERA5 tropospheric delay model (only available if tropospheric delay correction was performed)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e0bc3f5-7e2f-4fc1-bbec-c542120bb499",
+   "id": "1c0bb534-6d25-4bd9-8584-50137624fa6e",
    "metadata": {},
    "outputs": [],
    "source": [
     "import mintpy.cli.save_gdal as save_gdal\n",
     "\n",
     "velocity_path = mint_path / 'velocity.h5'\n",
-    "era_corr_velocity_path = mint_path / 'velocityERA5.h5'\n",
-    "velocity_path = era_corr_velocity_path if era_corr_velocity_path.exists() else velocity_path\n",
-    "vel_tiff = geotiff_path / f'{velocity_path.stem}.tif'\n",
+    "velocity_era5_path = mint_path / 'velocityERA5.h5'\n",
+    "paths = [velocity_path, velocity_era5_path]\n",
     "\n",
-    "args = f'{velocity_path} --of GTIFF -o {vel_tiff}'\n",
-    "save_gdal.main(args.split())"
+    "for path in paths:\n",
+    "    try:\n",
+    "        args = f'{path} --of GTIFF -o {geotiff_path / path.stem}.tif'\n",
+    "        # print(args)\n",
+    "        save_gdal.main(args.split())\n",
+    "    except FileNotFoundError:\n",
+    "        pass"
    ]
   },
   {
@@ -562,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/Output_GeoTiff.ipynb
+++ b/Output_GeoTiff.ipynb
@@ -148,12 +148,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ifgramstack = inputs_path/\"ifgramStack.h5\"\n",
-    "\n",
-    "with h5py.File(ifgramstack, \"r\") as f:\n",
+    "with h5py.File(ts_demErr_path, \"r\") as f:\n",
     "    dates = f[\"date\"][()]\n",
-    "    dates = list(set([d.decode(\"utf-8\") for insar in dates for d in insar]))\n",
-    "    dates.sort()"
+    "    dates = [d.decode() for d in dates]"
    ]
   },
   {
@@ -466,7 +463,6 @@
     "for path in paths:\n",
     "    try:\n",
     "        args = f'{path} --of GTIFF -o {geotiff_path / path.stem}.tif'\n",
-    "        # print(args)\n",
     "        save_gdal.main(args.split())\n",
     "    except FileNotFoundError:\n",
     "        pass"


### PR DESCRIPTION
- fixes #39 
    - Output both velocity.h5 and velocityERA5.h5 (when available) to geotiff. 
- Build the list of dates for unwrapped and wrapped interferogram geotiff generation from timeseries file instead of the ifgramStack file, so dropped time steps are skipped. The code previously attempted to create geotiffs for the complete list of original dates in ifgramStack, and would fail on removed dates for which no data were present. The timeseries files contain the filtered list of time steps, which are all backed by valid data.